### PR TITLE
Remove bottom-right margin boxes referencing Antenna House

### DIFF
--- a/original-htmls/block/css-text-overflow-1/css-text-overflow-1.html
+++ b/original-htmls/block/css-text-overflow-1/css-text-overflow-1.html
@@ -9,15 +9,6 @@
     @page {
       size: 210mm 297mm;
       margin: 10mm 20mm;
-      @bottom-right {
-        content: 'Antenna House, Inc.';
-        font-size: 8pt;
-        color: green;
-        text-align: right;
-        -ah-link: url('https://www.antennahouse.com/');
-        -ah-link-alt-text: 'Antenna House, Inc.';
-        -ah-link-show-annotation: true;
-      }
     }
     body {
       font-family: serif;

--- a/original-htmls/character/css-font-face-2/css-font-face-2.html
+++ b/original-htmls/character/css-font-face-2/css-font-face-2.html
@@ -11,14 +11,6 @@
     @page {
       size: 210mm 297mm;
       margin: 10mm 20mm 10mm 20mm;
-      @bottom-right {
-        content: "Antenna House, Inc.";
-        font-size: 0.8em;
-        color: green;
-        text-align: right;
-        -ah-link: url("https://www.antennahouse.com/");
-        -ah-link-alt-text: "Antenna House, Inc.";
-      }
     }
     body {
       font-family: serif;

--- a/original-htmls/character/css-initial-letters/css-initial-letters.html
+++ b/original-htmls/character/css-initial-letters/css-initial-letters.html
@@ -18,19 +18,6 @@
             margin: 0;
         }
 
-        @bottom-right {
-            content: "Antenna House, Inc.";
-            height: 15mm;
-            font-size: 0.8em;
-            color: green;
-            vertical-align: bottom;
-            text-align: right;
-            -ah-pdftag: Artifact;
-            margin-bottom: 10mm;
-            -ah-hyperlink: url("https://www.antennahouse.com");
-            -ah-alttext: "Antenna House, Inc.";
-            -ah-annotation-contents: "Antenna House, Inc.";
-        }
     }
 
    

--- a/original-htmls/float/css-table-float-move-1/css-table-float-move-1.html
+++ b/original-htmls/float/css-table-float-move-1/css-table-float-move-1.html
@@ -17,15 +17,6 @@
       margin: 10mm 20mm 10mm 20mm;
 
       /* region-after (15mm high) → approximate with bottom-right margin box */
-      @bottom-right {
-        content: "Antenna House, Inc.";
-        color: green;
-        font-size: 0.8em;
-        text-align: right;
-        -ah-link: url("https://www.antennahouse.com/");
-        -ah-link-alt-text: "Antenna House, Inc.";
-        -ah-link-show-annotation: true;
-      }
     }
 
     body {

--- a/original-htmls/graphics/css-3d-embedding/css-3d-embedding.html
+++ b/original-htmls/graphics/css-3d-embedding/css-3d-embedding.html
@@ -23,17 +23,6 @@
             }
 
             
-             @bottom-right {
-                 height: 18mm;
-                 content: 'Antenna House, Inc.';
-                 font-size: 0.8em;
-                 text-align: right;
-                 color: green;
-                 -ah-link: url('https://www.antennahouse.com/');
-                 -ah-link-alt-text: 'Antenna House, Inc.';
-                 -ah-pdftag: Artifact; 
-                 -ah-link-annotation-contents: 'Antenna House, Inc.'; 
-            }
             
 
             

--- a/original-htmls/language/css-language-nl-1/css-language-nl-1.html
+++ b/original-htmls/language/css-language-nl-1/css-language-nl-1.html
@@ -22,13 +22,6 @@
     margin-right: 20mm;
     margin-bottom: 17mm;
 
-    @bottom-right {
-      content: "Antenna House, Inc.";
-      font-size: 0.8em;
-      color: green;
-      vertical-align: top;
-      padding-bottom: 10mm;
-    }
   }
 
   body {

--- a/original-htmls/line/css-flush-zone-1/css-flush-zone-1.html
+++ b/original-htmls/line/css-flush-zone-1/css-flush-zone-1.html
@@ -11,14 +11,6 @@
     @page {
       size: 210mm 297mm;
       margin: 10mm 20mm 10mm 20mm;
-      @bottom-right {
-        content: "Antenna House, Inc.";
-        font-size: 0.8em;
-        color: green;
-        text-align: right;
-        -ah-link: url("https://www.antennahouse.com/");
-        -ah-link-alt-text: "Antenna House, Inc.";
-      }
     }
     body {
       font-family: serif;

--- a/original-htmls/line/css-line-number-2/css-line-number-2.html
+++ b/original-htmls/line/css-line-number-2/css-line-number-2.html
@@ -11,14 +11,6 @@
     @page {
       size: 210mm 150mm;
       margin: 10mm 20mm 10mm 20mm;
-      @bottom-right {
-        content: "Antenna House, Inc.";
-        font-size: 0.8em;
-        color: green;
-        text-align: right;
-        -ah-link: url("https://www.antennahouse.com/");
-        -ah-link-alt-text: "Antenna House, Inc.";
-      }
     }
     body {
       font-family: serif;

--- a/original-htmls/line/css-line-number-show-1/css-line-number-show-1.html
+++ b/original-htmls/line/css-line-number-show-1/css-line-number-show-1.html
@@ -11,14 +11,6 @@
     @page {
       size: 210mm 297mm;
       margin: 10mm 20mm 10mm 20mm;
-      @bottom-right {
-        content: "Antenna House, Inc.";
-        font-size: 0.8em;
-        color: green;
-        text-align: right;
-        -ah-link: url("https://www.antennahouse.com/");
-        -ah-link-alt-text: "Antenna House, Inc.";
-      }
     }
     body {
       font-family: serif;

--- a/original-htmls/page-set/css-marker-1/css-marker-1.html
+++ b/original-htmls/page-set/css-marker-1/css-marker-1.html
@@ -16,16 +16,6 @@
             @top-right {
                 content: element(thumbindex);
             }
-            @bottom-right {
-                content: 'Antenna House, Inc.';
-                font-size: 8pt;
-                color: green;
-                text-align: right;
-                margin: 7mm;
-                -ah-link: url('https://www.antennahouse.com/');
-                -ah-link-alt-text: 'Antenna House, Inc.';
-                -ah-link-show-annotation: true;
-            }
         }
 
         body {

--- a/original-htmls/pdf-features/css-Bookmark-1/css-Bookmark-1.html
+++ b/original-htmls/pdf-features/css-Bookmark-1/css-Bookmark-1.html
@@ -6,15 +6,6 @@
 @page {
     size: 210mm 297mm;
     margin: 10mm 20mm 10mm 20mm;
-    @bottom-right {
-                content: 'Antenna House, Inc.';
-                font-size: 8pt;
-                color: green;
-                text-align: right;
-                -ah-link: url('https://www.antennahouse.com/');
-                -ah-link-alt-text: 'Antenna House, Inc.';
-                -ah-link-show-annotation: true;
-            }
     }
 
 /* Basic styles */

--- a/original-htmls/pdf-features/css-pdf-embedding-2/css-pdf-embedding-2.html
+++ b/original-htmls/pdf-features/css-pdf-embedding-2/css-pdf-embedding-2.html
@@ -9,11 +9,6 @@
     @page {
       size: A4 portrait;
       margin: 10mm 20mm;
-      @bottom-right {
-        content: "Antenna House, Inc.";
-        color: green;
-        font-size: 0.8em;
-      }
     }
 
     body {

--- a/original-htmls/pdf-features/css-pdf-embedding-3/css-pdf-embedding-3.html
+++ b/original-htmls/pdf-features/css-pdf-embedding-3/css-pdf-embedding-3.html
@@ -23,19 +23,6 @@
             background-image: url("order.pdf");
        }
 
-        @page {
-            @bottom-right {
-                height: 18mm;
-                content: 'Antenna House, Inc.';
-                font-size: 0.8em;
-                text-align: right;
-                color: green;
-                -ah-link: url('https://www.antennahouse.com/');
-                -ah-link-alt-text: 'Antenna House, Inc.';
-                -ah-pdftag: Artifact;
-                -ah-link-annotation-contents: 'Antenna House, Inc.';
-            }
-        }
 
         .page-sequence-1 {
             page: PageMaster1;

--- a/original-htmls/structure/css-region-2/css-region-2.html
+++ b/original-htmls/structure/css-region-2/css-region-2.html
@@ -13,24 +13,8 @@
   -ah-float: page bottom;
   }
 }
-@page :right {
-  @bottom-right {
-    content: "Antenna House, Inc.";
-    font-size: 0.8em;
-    color: green;
-    text-align: right;
-    -ah-outside-align: outside; /* On right pages, this will be the outside edge */
-  }
 }
 
-@page :left {
-  @bottom-left {
-    content: "Antenna House, Inc.";
-    font-size: 0.8em;
-    color: green;
-    text-align: left;
-    -ah-outside-align: outside; /* On left pages, this will be the outside edge */
-  }
 }
 
 .before-float-content {

--- a/original-htmls/structure/css-side-note-1/css-side-note-1.html
+++ b/original-htmls/structure/css-side-note-1/css-side-note-1.html
@@ -24,14 +24,6 @@
 
 @page:left {
   margin: 10mm 20mm 10mm 50mm;
-            @bottom-left {
-				content: 'Antenna House, Inc.';
-				font-size: 8pt;
-				color: green;
-				text-align: left;
-				-ah-link: url('https://www.antennahouse.com/');
-				-ah-link-alt-text: 'Antenna House, Inc.';
-				-ah-link-show-annotation: true;
 			}  @sidenote {
     -ah-float: left;
     -ah-float-offset-x: -35mm;
@@ -41,15 +33,6 @@
 
 @page:right {
   margin: 10mm 50mm 10mm 20mm;
-			@bottom-right {
-				content: 'Antenna House, Inc.';
-				font-size: 8pt;
-				color: green;
-				text-align: right;
-				-ah-link: url('https://www.antennahouse.com/');
-				-ah-link-alt-text: 'Antenna House, Inc.';
-				-ah-link-show-annotation: true;
-			}
   @sidenote {
     -ah-float: right;
     -ah-float-offset-x: -35mm;

--- a/original-htmls/table/css-table-function-sample/css-table-function-sample.html
+++ b/original-htmls/table/css-table-function-sample/css-table-function-sample.html
@@ -7,14 +7,6 @@
         @page {
             size: A4;
             margin: 10mm 20mm;
-            @bottom-right {
-                content: "Antenna House, Inc.";
-                font-size: 0.8em;
-                color: green;
-                -ah-link: url(https://www.antennahouse.com/);
-                -ah-text-align: outside;
-                -ah-pdftag: "Artifact";
-            }
         }
 
         body {

--- a/original-htmls/table/css-table-headers-scope-1/css-table-headers-scope-1.html
+++ b/original-htmls/table/css-table-headers-scope-1/css-table-headers-scope-1.html
@@ -9,16 +9,6 @@
         @page {
             size: 210mm 297mm;
             margin: 10mm 20mm 10mm 20mm;
-			@bottom-right {
-				content: 'Antenna House, Inc.';
-				font-size: 8pt;
-				color: green;
-				text-align: right;
-				-ah-link: url('https://www.antennahouse.com/');
-				-ah-link-alt-text: 'Antenna House, Inc.';
-				-ah-link-show-annotation: true;
-                height: 7em;
-			}
         }
         
         body {

--- a/original-htmls/table/css-table-retrieve-table-marker/css-table-retrieve-table-marker.html
+++ b/original-htmls/table/css-table-retrieve-table-marker/css-table-retrieve-table-marker.html
@@ -9,15 +9,6 @@
         @page {
             size: 210mm 150mm;
             margin: 10mm 20mm;
-            @bottom-right {
-                content: 'Antenna House, Inc.';
-                font-size: 8pt;
-                color: green;
-                text-align: right;
-                -ah-link: url('https://www.antennahouse.com/');
-                -ah-link-alt-text: 'Antenna House, Inc.';
-                -ah-link-show-annotation: true;
-            }
         }
         body {
             font-family: serif;


### PR DESCRIPTION
## Summary
- strip Antenna House footer boxes from multiple HTML samples
- clean up leftover `@bottom` placeholders

## Testing
- `grep -n "@bottom"` on modified files

------
https://chatgpt.com/codex/tasks/task_e_6860394ed754832091e3b8200e159dea