### PR TITLE
Update font-face examples

### DIFF
--- a/original-htmls/html/character/css-font-face-1.html
+++ b/original-htmls/html/character/css-font-face-1.html
@@ -9,7 +9,7 @@
 				@font-face
 				{
 					font-family: 'Shakespeare';
-					src: url('ILShakeFest.ttf') format('truetype');
+                                       src: url('../../fonts/ILShakeFest.ttf') format('truetype');
 				}
 				.codePrint
 				{
@@ -45,8 +45,8 @@
 		</p>
 		<div class = "contentBox">
 			&lt;style&gt;
-			@font-face{ font-family: Shakespeare;
-			src: url('ILShakeFest.ttf') format('truetype');" }<br>
+                        @font-face{ font-family: Shakespeare;
+                        src: url('../../fonts/ILShakeFest.ttf') format('truetype');" }<br>
 			&lt;/style&gt; <br>
 			... <br>
 			&lt;p style = "text-align: center; font-family: Shakespeare; font-size: 3em;"&gt;Shakespeare&lt;/p&gt;

--- a/original-htmls/html/character/css-font-face-2.html
+++ b/original-htmls/html/character/css-font-face-2.html
@@ -49,20 +49,20 @@
     }
     @font-face {
       font-family: "Shakespeare-Normal";
-      src: url("ILShakeFest.ttf") format("truetype");
+      src: url("../../fonts/ILShakeFest.ttf") format("truetype");
     }
     @font-face {
       font-family: "Shakespeare";
-      src: url("ILShakeFest.ttf") format("truetype");
+      src: url("../../fonts/ILShakeFest.ttf") format("truetype");
       unicode-range: U+0040-0060;
     }
     @font-face {
       font-family: "MySourceHanSans";
-      src: url("SourceHanSans-Regular.otf") format("opentype");
+      src: url("../../fonts/SourceHanSans-Regular.otf") format("opentype");
     }
     @font-face {
       font-family: "MySourceHanSans-adjust";
-      src: url("SourceHanSans-Regular.otf") format("opentype");
+      src: url("../../fonts/SourceHanSans-Regular.otf") format("opentype");
       -ah-size-adjust: 0.85;
     }
     pre {
@@ -103,9 +103,9 @@
     <pre>
 &lt;!-- Example: specifying two fonts with different unicode-ranges --&gt;
 &lt;@font-face font-family="Shakespeare-Normal"
-  src="url('ILShakeFest.ttf')" /&gt;  
+  src="url('../../fonts/ILShakeFest.ttf')" /&gt;
 &lt;@font-face font-family="Shakespeare"
-  src="url('ILShakeFest.ttf')" 
+  src="url('../../fonts/ILShakeFest.ttf')"
   unicode-range="U+0040-0060" /&gt;
     </pre>
     <div style="margin-top:0.5em; font-family:Shakespeare-Normal,serif; font-size:1.2em;">
@@ -126,9 +126,9 @@
 &lt;!-- Example: specifying two versions of Source Han Sans,
    one with size-adjust for balancing English text --&gt;
 &lt;@font-face font-family="MySourceHanSans"
-  src="url('SourceHanSans-Regular.otf')" /&gt;   
+  src="url('../../fonts/SourceHanSans-Regular.otf')" /&gt;
 &lt;@font-face font-family="MySourceHanSans-adjust"
-  src="url('SourceHanSans-Regular.otf')"
+  src="url('../../fonts/SourceHanSans-Regular.otf')"
   size-adjust="0.85" /&gt;
     </pre>
     <div lang="ja" style="margin-top:0.5em; font-family:Arial,MySourceHanSans; font-size:1.2em;">


### PR DESCRIPTION
## Summary
- fix `@font-face` src paths for ILShakeFest and SourceHanSans fonts
- update code snippets to reflect the new font locations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac5d533c8320a67cb5536a1a9789