### PR TITLE
Fix image paths in HTML examples

### DIFF
--- a/original-htmls/html/block/css-column-fill-1.html
+++ b/original-htmls/html/block/css-column-fill-1.html
@@ -65,7 +65,7 @@
 			</div>
 			Content that cannot break, such as a graphic, can affect column heights.
 			<div class = "columnBox" style="-ah-column-fill: balance;">
-				<img src = "sunflower-2.jpg"> Lorem ipsum dolor sit amet, consectetur adipiscing elit bibendum tincidunt pharetra. Aenean ultricies molestie ante, sit amet ultricies nunc mollis id. Integer ut porttitor felis, vel tincidunt velit.
+				<img src = "../../img/sunflower-2.jpg"> Lorem ipsum dolor sit amet, consectetur adipiscing elit bibendum tincidunt pharetra. Aenean ultricies molestie ante, sit amet ultricies nunc mollis id. Integer ut porttitor felis, vel tincidunt velit.
 			</div>
 		</div>
 		<div>
@@ -85,7 +85,7 @@
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit bibendum tincidunt pharetra.Aenean ultricies molestie ante, sit amet ultricies nunc mollis id. Integer ut porttitor felis, vel tincidunt velit. Duis volutpat, quam quis aliquet tristique, nulla dui malesuada velit, et consectetur tellus ipsum et arcu. Ut tincidunt lorem erat, at elementum nibh varius consectetur. Sed viverra metus quis nibh pulvinar, at dignissim nibh adipiscing.
 			</div>
 			<div class = "columnBox" style = "-ah-column-fill: auto;">
-				<img src = "sunflower-2.jpg">
+				<img src = "../../img/sunflower-2.jpg">
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit bibendum tincidunt pharetra. Aenean ultricies molestie ante, sit amet ultricies nunc mollis id. Integer ut porttitor felis, vel tincidunt velit.
 			</div>
 		</div>

--- a/original-htmls/html/block/css-keep-together-1.html
+++ b/original-htmls/html/block/css-keep-together-1.html
@@ -59,7 +59,7 @@
 				Antenna House Formatter formats XSL Formatting Objects (XSL-FO), XML with XSL stylesheet, or HTML with CSS. The formatted result will be displayed in GUI and outputted or printed to PDF. (Display and printing are available only with the Windows version).
 			</p>
 			The work flow is as shown below.
-			<img src = "workflow70-wo-rx.png">
+			<img src = "../../img/workflow70-wo-rx.png">
 		</div>
 		<h3 style = "page-break-before: always;">
 			Blocks with background color have <span class = "codePrint">keep-together.within.page: always;</span> is specified
@@ -70,7 +70,7 @@
 				Antenna House Formatter formats XSL Formatting Objects (XSL-FO), XML with XSL stylesheet, or HTML with CSS. The formatted result will be displayed in GUI and outputted or printed to PDF. (Display and printing are available only with the Windows version).
 			</p>
 			The work flow is as shown below.
-			<img src = "workflow70-wo-rx.png">
+			<img src = "../../img/workflow70-wo-rx.png">
 		</div>
 		<div class = "subheading" style = "page-break-before: always;">
 			Place consecutive blocks in the same column
@@ -82,7 +82,7 @@
 				Antenna House Formatter formats XSL Formatting Objects (XSL-FO), XML with XSL stylesheet, or HTML with CSS. The formatted result will be displayed in GUI and outputted or printed to PDF. (Display and printing are available only with the Windows version).
 			</p>
 			The work flow is as shown below.
-			<img src = "workflow70-wo-rx.png">
+			<img src = "../../img/workflow70-wo-rx.png">
 		</div>
 			<h2>Blocks with background color have keep-together.within-column="always"</h2>
 		<div style = "columns: 200px 2; column-gap: 200px;">
@@ -93,7 +93,7 @@
 				Antenna House Formatter formats XSL Formatting Objects (XSL-FO), XML with XSL stylesheet, or HTML with CSS. The formatted result will be displayed in GUI and outputted or printed to PDF. (Display and printing are available only with the Windows version).
 			</p>
 			The work flow is as shown below.
-			<img src = "workflow70-wo-rx.png">
+			<img src = "../../img/workflow70-wo-rx.png">
 			</div>
 		</div>
 	</body>

--- a/original-htmls/html/color/css-color-Pantone-1.html
+++ b/original-htmls/html/color/css-color-Pantone-1.html
@@ -125,17 +125,17 @@
 			<tr>
 				<td style="padding-right: 0.2em;">
 					<div class = "image-container" style="width: 85%; -ah-content-width: scale-down-to-fit; content-height: scale-down-to-fit;">
-						<img src="pantone-all.png">
+						<img src="../../img/pantone-all.png">
 					</div>
 				</td>
 				<td style="padding-right: 0.2em;">
 					<div style="width: 85%; -ah-content-width: scale-down-to-fit; content-height: scale-down-to-fit;">
-						<img src="pantone-1.png">
+						<img src="../../img/pantone-1.png">
 					</div>
 				</td>
 				<td style="padding-right: 0.2em;">
 					<div style="width: 100%; -ah-content-width: scale-down-to-fit; content-height: scale-down-to-fit;">
-						<img src="pantone-2.png">
+						<img src="../../img/pantone-2.png">
 					</div>
 				</td>
 			</tr>

--- a/original-htmls/html/color/css-color-transparent-1.html
+++ b/original-htmls/html/color/css-color-transparent-1.html
@@ -47,7 +47,7 @@
 		</div>
 		<div>
 			<h2>Text selection</h2>
-			<img style = "border: solid thin black;"src = "transparent-invisible-text.png">
+			<img style = "border: solid thin black;"src = "../../img/transparent-invisible-text.png">
 		</div>
 	</body>
 

--- a/original-htmls/html/graphics/css-graphics-1.html
+++ b/original-htmls/html/graphics/css-graphics-1.html
@@ -53,13 +53,13 @@
 		</div>
 		
 		<p class = "codePrint">No settings to content-width, content-height</p>
-		<div><img src = "sunflower.jpg"></div>
+		<div><img src = "../../img/sunflower.jpg"></div>
 		
 		<p class = "codePrint">-ah-content-width: 5.0cm; -ah-content-height: 3.5cm;</p>
-		<div><img class = "img1" src = "sunflower.jpg"></div>
+		<div><img class = "img1" src = "../../img/sunflower.jpg"></div>
 		
 		<p>The arrangement of the loaded graphics in an element can be adjusted by display-align, text-align. The following example shows the center arrangement by specifying <span class = "codePrint">display-align: center;, text-align: center;</span>.</p>
-		<div><img class = "img2" src = "sunflower.jpg"></div>
+		<div><img class = "img2" src = "../../img/sunflower.jpg"></div>
 		
 		
 	</body>

--- a/original-htmls/html/graphics/css-graphics-cgm-1.html
+++ b/original-htmls/html/graphics/css-graphics-cgm-1.html
@@ -39,7 +39,7 @@
 			Source: <a href="https://www.w3.org/Graphics/WebCGM/2009/WebCGM21/testsuite21.html">WebCGM 2.1 Test Suite</a>. Copyright © 2002-2006, Lofton Henderson. All Rights Reserved.
 		</div>
 		<div style="-ah-margin-before: 1.5em;">
-			<img src="BIGCGM01.cgm" style="-ah-content-width: 150mm; border: thin solid gray;">
+			<img src="../../img/BIGCGM01.cgm" style="-ah-content-width: 150mm; border: thin solid gray;">
 			<div>
 				From WebCGM 2.1 Test Suite BIGCGM01.cgm.
 			</div>
@@ -52,13 +52,13 @@
 				<div>
 					AH Formatter V6.4
 					<div style="border: 1pt solid;">
-						<img src="SPECMD02.cgm" style="-ah-content-width: scale-down-to-fit; width: 80%;">
+						<img src="../../img/SPECMD02.cgm" style="-ah-content-width: scale-down-to-fit; width: 80%;">
 					</div>
 				</div>
 				<div>
 					AH Formatter V6.3
 					<div style="border: 1pt solid;">
-						<img src="SPECMD02-v63.png" style="-ah-content-width: scale-down-to-fit; width: 80%;">
+						<img src="../../img/SPECMD02-v63.png" style="-ah-content-width: scale-down-to-fit; width: 80%;">
 					</div>
 				</div>
 			</div>
@@ -72,13 +72,13 @@
 				<div>
 					AH Formatter V6.4
 					<div style="border: 1pt solid;">
-						<img src="alphaEscape.cgm" style="-ah-content-width: scale-down-to-fit; width: 80%;">
+						<img src="../../img/alphaEscape.cgm" style="-ah-content-width: scale-down-to-fit; width: 80%;">
 					</div>
 				</div>
 				<div style="-ah-keep-together.within-column: always;">
 					AH Formatter V6.3
 					<div style="border: 1pt solid;">
-						<img src="alphaEscape-v63.png" style="-ah-content-width: scale-down-to-fit; width: 80%;">
+						<img src="../../img/alphaEscape-v63.png" style="-ah-content-width: scale-down-to-fit; width: 80%;">
 					</div>
 				</div>
 			</div>
@@ -92,13 +92,13 @@
 				<div>
 					AH Formatter V6.4
 					<div style="border: 1pt solid;">
-						<img src="interpolated-interior-01.cgm" style="-ah-content-width: scale-down-to-fit; width: 80%;">
+						<img src="../../img/interpolated-interior-01.cgm" style="-ah-content-width: scale-down-to-fit; width: 80%;">
 					</div>
 				</div>
 				<div>
 					AH Formatter V6.3
 					<div style="border: 1pt solid;">
-						<img src="interpolated-interior-01-v63.png" style="-ah-content-width: scale-down-to-fit; width: 80%;">
+						<img src="../../img/interpolated-interior-01-v63.png" style="-ah-content-width: scale-down-to-fit; width: 80%;">
 					</div>
 				</div>
 			</div>

--- a/original-htmls/html/graphics/css-graphics-svg-1.html
+++ b/original-htmls/html/graphics/css-graphics-svg-1.html
@@ -32,7 +32,7 @@
 			Sample of reading and displaying an external SVG graphic:
 		</div>
 		<div style="text-align: center;">
-			<img src="svg-sample1.svg">
+			<img src="../../img/svg-sample1.svg">
 		</div>
 		<div style="-ah-margin-before: 2em;">
 			SVG can be included directly in CSS. In order to include SVG. The following SVG was produced by including SVG in CSS. The sample SVG markup is shown below.

--- a/original-htmls/html/graphics/css-graphics-svg-2.html
+++ b/original-htmls/html/graphics/css-graphics-svg-2.html
@@ -127,7 +127,7 @@
 						</defs>
 				   
 						
-						<image class="photo1" x="0" y="0" width="250" height="166" xlink:href="sunflower.jpg" xmlns:xlink="http://www.w3.org/1999/xlink">
+						<image class="photo1" x="0" y="0" width="250" height="166" xlink:href="../../img/sunflower.jpg" xmlns:xlink="http://www.w3.org/1999/xlink">
 				   </image>
 				   
 						<rect x="0" y="0" width="250" height="166" fill="lime" mask="url(#imagesMask)">

--- a/original-htmls/html/graphics/css-scale-to-fit-1.html
+++ b/original-htmls/html/graphics/css-scale-to-fit-1.html
@@ -73,48 +73,48 @@
 			<span class = "codePrint">No settings to content-width</span>
 		</p>
 		<div>
-			<img src = "sunflower.jpg">
+			<img src = "../../img/sunflower.jpg">
 		</div>
 		<p>
 			<span class = "codePrint">width: 4cm; height: 3cm; -ah-content-width: scale-to-fit;</span>
 		</p>
 		<div>
-			<img class = "imgFormat" src = "sunflower.jpg">
+			<img class = "imgFormat" src = "../../img/sunflower.jpg">
 		</div>
 		
 		<p>
 			<span class = "codePrint">width: 10cm; height: 7cm; -ah-content-width: scale-to-fit;</span>
 		</p>
 		<div>
-			<img class = "imgFormat" id = "iF_0" src = "sunflower.jpg">
+			<img class = "imgFormat" id = "iF_0" src = "../../img/sunflower.jpg">
 		</div>
 		
 		<p>
 			<span class = "codePrint">width: 4cm; height: 3cm; -ah-content-width: scale-down-to-fit;</span>
 		</p>
 		<div>
-			<img class = "imgFormat" id = "iF_1" src = "sunflower.jpg">
+			<img class = "imgFormat" id = "iF_1" src = "../../img/sunflower.jpg">
 		</div>
 		
 		<p>
 			<span class = "codePrint">width: 8cm; height: 6cm; -ah-content-width: scale-down-to-fit;</span>
 		</p>
 		<div>
-			<img class = "imgFormat" id = "iF_2" src = "sunflower.jpg">
+			<img class = "imgFormat" id = "iF_2" src = "../../img/sunflower.jpg">
 		</div>
 		
 		<p>
 			<span class = "codePrint">width: 8cm; height: 6cm; -ah-content-width: scale-up-to-fit;</span>
 		</p>
 		<div>
-			<img class = "imgFormat" id = "iF_3" src = "sunflower.jpg">
+			<img class = "imgFormat" id = "iF_3" src = "../../img/sunflower.jpg">
 		</div>
 		
 		<p>
 			<span class = "codePrint">width: 4cm; height: 3cm; -ah-content-width: scale-up-to-fit;</span>
 		</p>
 		<div>
-			<img class = "imgFormat" id = "iF_4" src = "sunflower.jpg">
+			<img class = "imgFormat" id = "iF_4" src = "../../img/sunflower.jpg">
 		</div>
 		
 	</body>

--- a/original-htmls/html/line/css-unbreakable-words-1.html
+++ b/original-htmls/html/line/css-unbreakable-words-1.html
@@ -66,7 +66,7 @@
 		</div>
 		<div>
 			If the option setting ‘<a href="https://www.antenna.co.jp/AHF/help/en/ahf-optset.html#unbreakable-words">unbreakable-words</a>’ is not applied, the result is as follows.
-			<img style="width: 100%; -ah-content-width: scale-to-fit;" src="v7-not-unbreak-en.png">
+			<img style="width: 100%; -ah-content-width: scale-to-fit;" src="../../img/v7-not-unbreak-en.png">
 		</div>
 	</body>
 

--- a/original-htmls/html/pdf-features/css-document-info-2.html
+++ b/original-htmls/html/pdf-features/css-document-info-2.html
@@ -36,7 +36,7 @@
 		</div>
 		<div>
 			<div class = "floatMedia">
-				<img src="pagelayout-gui.png" width="150px">
+				<img src="../../img/pagelayout-gui.png" width="150px">
 			</div>
 			<div>
 				This example uses the four-page document shown opened in the Antenna House Formatter GUI in the screenshot on the right.
@@ -47,7 +47,7 @@
 		</div>
 		<div style="margin-top: 10em;">
 			<div class = "floatMedia">
-				<img src="SinglePage.png" width="70px">
+				<img src="../../img/SinglePage.png" width="70px">
 			</div>
 			<h2>
 				&lt;meta name="pagelayout" Content="SinglePage"&gt;
@@ -58,7 +58,7 @@
 		</div>
 		<div style="margin-top: 3em;">
 			<div class = "floatMedia">
-				<img src="TwoPageLeft.png" width="100px">
+				<img src="../../img/TwoPageLeft.png" width="100px">
 			</div>
 			<h2>
 				&lt;meta name="pagelayout" Content="TwoPageLeft"&gt;
@@ -72,7 +72,7 @@
 		</div>
 		<div style="margin-top: 0.5em;">
 			<div class = "floatMedia">
-				<img src="TwoPageRight.png" width="70px">
+				<img src="../../img/TwoPageRight.png" width="70px">
 			</div>
 			<h2>
 				&lt;meta name="pagelayout" Content="TwoPageRight"&gt;
@@ -83,7 +83,7 @@
 		</div>
 		<div style="margin-top: 2em;">
 			<div class = "floatMedia">
-				<img src="TwoPageRight-2-3.png" width="100px">
+				<img src="../../img/TwoPageRight-2-3.png" width="100px">
 			</div>
 			<div>
 				When the document is scrolled, the PDF viewer shows pages 2 and 3, then pages 4 and 5, and so on.
@@ -94,7 +94,7 @@
 		</div>
 		<div style="margin-top: 2em; break-before: page;">
 			<div class = "floatMedia">
-				<img src="OneColumn.png" width="60px">
+				<img src="../../img/OneColumn.png" width="60px">
 			</div>
 			<h2>
 				&lt;meta name="pagelayout" Content="OneColumn"&gt;
@@ -105,7 +105,7 @@
 		</div>
 		<div style="margin-top: 23em;">
 			<div class = "floatMedia">
-				<img src="TwoColumnLeft.png" width="100px">
+				<img src="../../img/TwoColumnLeft.png" width="100px">
 			</div>
 			<h2>
 				&lt;meta name="pagelayout" Content="TwoColumnLeft"&gt;
@@ -116,7 +116,7 @@
 		</div>
 		<div style="margin-top: 10em;">
 			<div class = "floatMedia">
-				<img src="TwoColumnRight.png" width="100px">
+				<img src="../../img/TwoColumnRight.png" width="100px">
 			</div>
 			<h2>
 				&lt;meta name="pagelayout" Content="TwoColumnRight"&gt;

--- a/original-htmls/html/pdf-features/css-form-field-1.html
+++ b/original-htmls/html/pdf-features/css-form-field-1.html
@@ -93,9 +93,9 @@
 					-ah-field-button-face: 'Antenna House, Inc.';
 					-ah-field-button-face-down: 'Down';
 					-ah-field-button-face-rollover: Rollover;
-					-ah-field-button-icon: url('icon1.png');
-					-ah-field-button-icon-down: url('icon2.png');
-					-ah-field-button-icon-rollover: url('icon3.png');
+					-ah-field-button-icon: url('../../img/icon1.png');
+					-ah-field-button-icon-down: url('../../img/icon2.png');
+					-ah-field-button-icon-rollover: url('../../img/icon3.png');
 					width: 15em;
 					height: 3em;
 					background-color: #eee;

--- a/original-htmls/html/pdf-features/css-overprint-1.html
+++ b/original-htmls/html/pdf-features/css-overprint-1.html
@@ -72,7 +72,7 @@
 		<div>
 			The following image indicates that  the color of the characters in the left sample above and the color of the top overlapping object in the right samples are specified to be hidden in the preview of the color separation in Adobe Acrobat. In the overprint setting, the  one color is printed on top of another; therefore, even when the color of the characters and the color of the top object are set to be hidden, the color of the bottom object will be kept.
 		</div>
-		<img src="overprint-1.png">
+		<img src="../../img/overprint-1.png">
 	</body>
 
 </html>

--- a/original-htmls/html/pdf-features/css-printer-marks-1.html
+++ b/original-htmls/html/pdf-features/css-printer-marks-1.html
@@ -8,7 +8,7 @@
 			<style>
 				@page
 				{
-					-ah-marks: crop cross url('colorbar.svg');
+					-ah-marks: crop cross url('../../img/colorbar.svg');
 					-ah-printer-marks-line-width: 0.25pt;
 					-ah-crop-offset: 20mm 14mm 20mm 14mm;
 					-ah-bleed: 4mm;

--- a/original-htmls/html/structure/css-background-clip-1.html
+++ b/original-htmls/html/structure/css-background-clip-1.html
@@ -25,7 +25,7 @@
 					border: 5pt dashed rgb(0,61,25);
 					-ah-background-origin: border-box;
 					-ah-background-clip: border-box;
-					-ah-background-image: url('background-size-background-lightblue.svg'), url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background-lightblue.svg'), url('../../img/background-size-background.svg');
 					background-repeat: no-repeat, repeat;
 				}
 				#dBB_0
@@ -95,7 +95,7 @@
 			In the following examples, the dotted border indicates the extent of the content box of the outer block, and the text indicates the <span class = "codePrint">-ah-background-clip</span> value. All background images are the same size.
 		</p>
 		<p style = "text-indent: 1em;">
-			The examples use these images for repeated and non-repeated backgrounds, respectively: <img src = "background-size-background.svg"> and <img src = "background-size-background-lightblue.svg">
+			The examples use these images for repeated and non-repeated backgrounds, respectively: <img src = "../../img/background-size-background.svg"> and <img src = "../../img/background-size-background-lightblue.svg">
 		</p>
 		<table>
 			<tr>

--- a/original-htmls/html/structure/css-background-content-height-1.html
+++ b/original-htmls/html/structure/css-background-content-height-1.html
@@ -10,7 +10,7 @@
 				{
 					page-height: 150mm;
 					page-width: 210mm;
-					-ah-background-image: url('peace.svg');
+					-ah-background-image: url('../../img/peace.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-position: center;
 					-ah-background-size: 50%;

--- a/original-htmls/html/structure/css-background-image-1.html
+++ b/original-htmls/html/structure/css-background-image-1.html
@@ -16,7 +16,7 @@
 			}
 			.backgroundRepeat
 			{
-				background-image: url("peace.svg");
+				background-image: url("../../img/peace.svg");
 				background-repeat: repeat;
 				width: 100%;
 				height: 450px;
@@ -44,10 +44,10 @@
 		</div>
 		
 		<div class = "imgcentered">
-			<img src = "peace.svg">
+			<img src = "../../img/peace.svg">
 		</div>
 		<div class = "backgroundRepeat" style = "page-break-before: always;">
-			<img src = "peace.svg">
+			<img src = "../../img/peace.svg">
 		</div>
 	</body>
 

--- a/original-htmls/html/structure/css-background-image-2.html
+++ b/original-htmls/html/structure/css-background-image-2.html
@@ -23,7 +23,7 @@
 					height: 50pt;
 					width: 100pt;
 					border: 5pt dashed rgb(0,61,25);
-					-ah-background-image: url('background-size-background-lightblue.svg'), url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background-lightblue.svg'), url('../../img/background-size-background.svg');
 				}
 				#dBB_0
 				{
@@ -63,7 +63,7 @@
 			In the following examples, the dotted border indicates the extent of the content box of the outer block, and the text indicates the <span class = "codePrint">-ah-background-clip</span> value. All background images are the same size.
 		</p>
 		<p style = "text-indent: 1em;">
-			The examples use these images for repeated and non-repeated backgrounds, respectively: <img src = "background-size-background.svg"> and <img src = "background-size-background-lightblue.svg">
+			The examples use these images for repeated and non-repeated backgrounds, respectively: <img src = "../../img/background-size-background.svg"> and <img src = "../../img/background-size-background-lightblue.svg">
 		</p>
 		<h2>No other properties</h2>
 		<p>

--- a/original-htmls/html/structure/css-background-origin-1.html
+++ b/original-htmls/html/structure/css-background-origin-1.html
@@ -33,7 +33,7 @@
 					width: 100pt;
 					border: 5pt dashed rgb(0,61,25);
 					-ah-background-origin: border-box;
-					-ah-background-image: url('background-size-background-lightblue.svg'), url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background-lightblue.svg'), url('../../img/background-size-background.svg');
 					background-repeat: no-repeat;
 				}
 				#dBB_0
@@ -115,7 +115,7 @@
 			In the following examples, the dotted border indicates the extent of the content box of the outer block, and the text indicates the <span class = "codePrint">-ah-background-clip</span> value. All background images are the same size.
 		</p>
 		<p style = "text-indent: 1em;">
-			The examples use these images for repeated and non-repeated backgrounds, respectively: <img src = "background-size-background.svg"> and <img src = "background-size-background-lightblue.svg">
+			The examples use these images for repeated and non-repeated backgrounds, respectively: <img src = "../../img/background-size-background.svg"> and <img src = "../../img/background-size-background-lightblue.svg">
 		</p>
 		<table>
 			<tr>

--- a/original-htmls/html/structure/css-background-repeat-1.html
+++ b/original-htmls/html/structure/css-background-repeat-1.html
@@ -25,7 +25,7 @@
 					height: 60pt;
 					width: 100pt;
 					border: thin solid rgb(0,61,25);
-					background-image: url('background-size-background.png');
+					background-image: url('../../img/background-size-background.png');
 					background-repeat: no-repeat;
 					vertical-align: top;
 					text-align: left;
@@ -147,7 +147,7 @@
 			<p>
 				The text in the following examples indicates the ‘background-repeat’ value.
 			</p>
-			The examples use this background image: <img src = "background-size-background.png">
+			The examples use this background image: <img src = "../../img/background-size-background.png">
 		</div>
 		<table>
 			<tr>

--- a/original-htmls/html/structure/css-background-size-1.html
+++ b/original-htmls/html/structure/css-background-size-1.html
@@ -34,14 +34,14 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 				}
 				#iC_1
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: contain;
 				}
@@ -49,7 +49,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: cover;
 				}
@@ -57,7 +57,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: 100%;
 				}
@@ -65,7 +65,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: auto 100%;
 				}
@@ -73,7 +73,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: 100% 100%;
 				}
@@ -81,7 +81,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: 50%;
 				}
@@ -89,7 +89,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: auto 50%;
 				}
@@ -97,7 +97,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: 50% 50%;
 				}
@@ -105,7 +105,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: 50% 100%;
 				}
@@ -113,7 +113,7 @@
 				{
 					border: thin solid #003D19;
 					padding: 2pt;
-					-ah-background-image: url('background-size-background.svg');
+					-ah-background-image: url('../../img/background-size-background.svg');
 					-ah-background-repeat: no-repeat;
 					-ah-background-size: 100% 50%;
 				}
@@ -137,7 +137,7 @@
 			<tr>
 				<td>
 					<div class = "imgContainer">
-					<img src = "background-size-background.svg"><br>
+					<img src = "../../img/background-size-background.svg"><br>
 					Image used as a non-repeating background image
 					</div>
 				</td>

--- a/original-htmls/html/table/css-justify-rowspan-height-1.html
+++ b/original-htmls/html/table/css-justify-rowspan-height-1.html
@@ -94,9 +94,9 @@
 		</div>
 		<div style="text-align: center; font-weight: bold; margin-top: 1em;">
 			justify-rowspan-height: false;
-			<img src = "justify-rowspan-false.jpg"><br>
+			<img src = "../../img/justify-rowspan-false.jpg"><br>
 			justify-rowspan-height: true;
-			<img src="justify-rowspan-true.jpg">
+			<img src="../../img/justify-rowspan-true.jpg">
 		</div>
 	</body>
 

--- a/original-htmls/html/table/css-table-background-1.html
+++ b/original-htmls/html/table/css-table-background-1.html
@@ -201,7 +201,7 @@
 						#FFFF99
 					</td>
 					<td>
-						<img src = "table-background-table.png">
+						<img src = "../../img/table-background-table.png">
 					</td>
 				</tr>
 				<tr>
@@ -212,7 +212,7 @@
 						#FFC2A3
 					</td>
 					<td>
-						<img src = "table-background-column.png">
+						<img src = "../../img/table-background-column.png">
 					</td>
 				</tr>
 				<tr>
@@ -223,7 +223,7 @@
 						#FFADC9
 					</td>
 					<td>
-						<img src = "table-background-header.png">
+						<img src = "../../img/table-background-header.png">
 					</td>
 				</tr>
 			</table>
@@ -248,7 +248,7 @@
 						#D6C2FF
 					</td>
 					<td>
-						<img src = "table-background-footer.png">
+						<img src = "../../img/table-background-footer.png">
 					</td>
 				</tr>
 				<tr>
@@ -259,7 +259,7 @@
 						#CCDDFF
 					</td>
 					<td>
-						<img src = "table-background-row.png">
+						<img src = "../../img/table-background-row.png">
 					</td>
 				</tr>
 				<tr>
@@ -270,7 +270,7 @@
 						#D4FFFF
 					</td>
 					<td>
-						<img src = "table-background-cell.png">
+						<img src = "../../img/table-background-cell.png">
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
## Summary
- reference images from the shared `img` folder in several HTML samples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860adeaf1f083209eefab1ca349d8a9