### PR TITLE
Add booklet CSS to sample HTMLs

### DIFF
--- a/original-htmls/html/adv-forms/css-dynamic-content-change.html
+++ b/original-htmls/html/adv-forms/css-dynamic-content-change.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Dynamic Listbox Content Change</title>
     <meta name="author" content="user name">

--- a/original-htmls/html/adv-forms/css-form-demo-1.html
+++ b/original-htmls/html/adv-forms/css-form-demo-1.html
@@ -1,5 +1,8 @@
 <html>
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 <meta charset="UTF-8">
 <title>formdemo.fo converted for Antenna House Formatter</title>
 <style>

--- a/original-htmls/html/barcode/css-barcode-1.html
+++ b/original-htmls/html/barcode/css-barcode-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <title>Barcode – Antenna House, Inc.</title>
   <meta name="title" content="Barcode – Antenna House, Inc.">

--- a/original-htmls/html/barcode/css-barcode-color-size-1.html
+++ b/original-htmls/html/barcode/css-barcode-color-size-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Barcode color and size – Antenna House, Inc.</title>
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/block/css-text-overflow-1.html
+++ b/original-htmls/html/block/css-text-overflow-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <title>Rendering where inline content overflows – Antenna House, Inc.</title>
   <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/character/css-font-face-2.html
+++ b/original-htmls/html/character/css-font-face-2.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <meta name="document-title" content="Specify the Unicode range of the font added by -ah-font-face, and adjust the font size – Antenna House, Inc.">
   <meta name="displaydoctitle" content="true">

--- a/original-htmls/html/character/css-initial-letters.html
+++ b/original-htmls/html/character/css-initial-letters.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Drop Caps – Antenna House, Inc.</title>
     <meta name="keywords" content="-ah-initial-letters">

--- a/original-htmls/html/float/css-table-float-move-1.html
+++ b/original-htmls/html/float/css-table-float-move-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <title>Float move examples – Antenna House, Inc.</title>
   <!--

--- a/original-htmls/html/graphics/css-3d-embedding.html
+++ b/original-htmls/html/graphics/css-3d-embedding.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Sample of 3D</title>
     <meta name="subject" content="">

--- a/original-htmls/html/language/css-language-nl-1.html
+++ b/original-htmls/html/language/css-language-nl-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 <meta charset="UTF-8">
 <meta name="author" content="Antenna House, Inc.">
 <meta name="keywords" content="xml:lang,text-replace-Dutch-IJ">

--- a/original-htmls/html/line/css-flush-zone-1.html
+++ b/original-htmls/html/line/css-flush-zone-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <meta name="document-title" content="Adjusts the space at the end of the last line – Antenna House, Inc.">
   <meta name="displaydoctitle" content="true">

--- a/original-htmls/html/line/css-leader-alignment.html
+++ b/original-htmls/html/line/css-leader-alignment.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 <meta name="author" content="Maxim Kerkula, Antenna House">
 <meta name="keywords" content="leader-alignment">
 <meta name="subject" content="leader-alignment">

--- a/original-htmls/html/line/css-line-number-2.html
+++ b/original-htmls/html/line/css-line-number-2.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <meta name="document-title" content="Independent line numbering in table columns – Antenna House, Inc.">
   <meta name="displaydoctitle" content="true">

--- a/original-htmls/html/line/css-line-number-show-1.html
+++ b/original-htmls/html/line/css-line-number-show-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <meta name="document-title" content="Line numbers to always show – Antenna House, Inc.">
   <meta name="displaydoctitle" content="true">

--- a/original-htmls/html/misc/CSS-punctuation-spacing.html
+++ b/original-htmls/html/misc/CSS-punctuation-spacing.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <meta name="author" content="Alex Critchfield, Antenna House">
     <meta name="keywords" content="extensions, punctuation, spacing, sample, example">

--- a/original-htmls/html/misc/css-document-info.html
+++ b/original-htmls/html/misc/css-document-info.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>document-info extension demonstration</title>
     <meta name="author" content="Alex Critchfield, Antenna House">

--- a/original-htmls/html/misc/css-float-in-change-bar.html
+++ b/original-htmls/html/misc/css-float-in-change-bar.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <title>Change-bar with child float example</title>
     <meta name="author" content="Alex Critchfield, Antenna House">
     <meta name="keywords" content="extensions, change-bar">

--- a/original-htmls/html/misc/css-font-from-external-link.html
+++ b/original-htmls/html/misc/css-font-from-external-link.html
@@ -1,5 +1,8 @@
 <html>
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 <meta charset="UTF-8">
 <title>font-face extension demonstration</title>
 <meta name="author" content="Alex Critchfield, Antenna House">

--- a/original-htmls/html/misc/css-table-omit.html
+++ b/original-htmls/html/misc/css-table-omit.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <meta name="author" content="Alex Critchfield, Antenna House">
     <meta name="keywords" content="extensions, value, table-omit-header-at-break, table-omit-footer-at-break">

--- a/original-htmls/html/misc/css-text-transform.html
+++ b/original-htmls/html/misc/css-text-transform.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>text-transform extended values example</title>

--- a/original-htmls/html/misc/css-zoom.html
+++ b/original-htmls/html/misc/css-zoom.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <title>Zoom Document</title>
   <meta name="displaydoctitle" content="true">

--- a/original-htmls/html/page-set/css-marker-1.html
+++ b/original-htmls/html/page-set/css-marker-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <title>Thumb index – Antenna House, Inc.</title>
   <meta name="title" content="Thumb Index">

--- a/original-htmls/html/pdf-features/css-Bookmark-1.html
+++ b/original-htmls/html/pdf-features/css-Bookmark-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 <title>PDF Bookmarks – Antenna House, Inc.</title>
 <style>
 @page {

--- a/original-htmls/html/pdf-features/css-form-field-event-1.html
+++ b/original-htmls/html/pdf-features/css-form-field-event-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Form Event – Antenna House, Inc.</title>
     <meta name="keywords" content="form,form-field,AcroForms,JavaScript,setAction,openaction">

--- a/original-htmls/html/pdf-features/css-import-annotation-types-1.html
+++ b/original-htmls/html/pdf-features/css-import-annotation-types-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Keeping the annotation in the embedded PDF – Antenna House, Inc.</title>
     <meta name="keywords" content="import-annotation-types">

--- a/original-htmls/html/pdf-features/css-multimedia-1.html
+++ b/original-htmls/html/pdf-features/css-multimedia-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 		<meta charset="UTF-8">
 				<meta name="displaydoctitle"
 				      content="true">

--- a/original-htmls/html/pdf-features/css-multimedia-treatment-1.html
+++ b/original-htmls/html/pdf-features/css-multimedia-treatment-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Embedded and External Multimedia Data – Antenna House, Inc.</title>
     <meta name="subject" content="The document subject">

--- a/original-htmls/html/pdf-features/css-pdf-embedding-1.html
+++ b/original-htmls/html/pdf-features/css-pdf-embedding-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>PDF Embedding – Antenna House, Inc.</title>
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/pdf-features/css-pdf-embedding-2.html
+++ b/original-htmls/html/pdf-features/css-pdf-embedding-2.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <title>PDF embedding by specifying pages</title>
   <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/pdf-features/css-pdf-embedding-3.html
+++ b/original-htmls/html/pdf-features/css-pdf-embedding-3.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Printing by merging embedded PDF – Antenna House, Inc.</title>
     <meta name="keywords" content="background-image, container element, position: absolute, PDF">

--- a/original-htmls/html/pdf-features/css-richmedia-1.html
+++ b/original-htmls/html/pdf-features/css-richmedia-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 <meta charset="UTF-8">
 <meta name="keywords" content="object,video,-ah-multimedia-treatment,content-type">
 <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/structure/css-axf-region-1.html
+++ b/original-htmls/html/structure/css-axf-region-1.html
@@ -1,5 +1,8 @@
 <html>
 	<head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 			<style>
 				@page
 				{

--- a/original-htmls/html/structure/css-change-bar-2.html
+++ b/original-htmls/html/structure/css-change-bar-2.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <title>Text or graphic in change bar – Antenna House, Inc.</title>
     <meta name="keywords" content="fo:change-bar-begin">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/structure/css-footnote-number-1.html
+++ b/original-htmls/html/structure/css-footnote-number-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
   <meta charset="UTF-8">
   <title>Creating a footnote number and specifying a default value</title>
   <style>

--- a/original-htmls/html/structure/css-region-1.html
+++ b/original-htmls/html/structure/css-region-1.html
@@ -1,5 +1,8 @@
 <html>
 	<head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 			<style>
 				@page
 				{

--- a/original-htmls/html/structure/css-region-2.html
+++ b/original-htmls/html/structure/css-region-2.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 		<meta charset="UTF-8">
 			<title>Creating regions in a body region</title>
 			<style>

--- a/original-htmls/html/table/css-table-function-sample.html
+++ b/original-htmls/html/table/css-table-function-sample.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 		<meta charset="UTF-8">
 			<title>Combining various table features</title>
 			<style>

--- a/original-htmls/html/table/css-table-headers-scope-1.html
+++ b/original-htmls/html/table/css-table-headers-scope-1.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Associating table body cells and table header cells – Antenna House, Inc.</title>
     <meta name="keywords" content="<table-cell,headers,scope,PDF/UA">

--- a/original-htmls/html/table/css-table-keep-together-overflow.html
+++ b/original-htmls/html/table/css-table-keep-together-overflow.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
 <meta charset="UTF-8">
 <title>Avoiding table-row overflow due to keep-together.within-*="always" – Antenna House, Inc.</title>
 <meta name="document-title" content="Avoiding table-row overflow due to keep-together.within-*=&quot;always&quot; – Antenna House, Inc.">

--- a/original-htmls/html/table/css-table-retrieve-table-marker.html
+++ b/original-htmls/html/table/css-table-retrieve-table-marker.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
+<link rel="stylesheet" href="../../css/booklet-page-en.css"/>
+<link rel="stylesheet" href="../../css/css-sample-en.css"/>
     <meta charset="UTF-8">
     <title>Adding a "continued" indicator when a table is split – Antenna House, Inc.</title>
     <meta name="keywords" content="running-elements, table-split, continued-indicator">


### PR DESCRIPTION
## Summary
- link booklet-print-4th.css, booklet-page-en.css, and css-sample-en.css in remaining samples

## Testing
- `grep -L 'booklet-print-4th.css' -r original-htmls/html/*.html 2>/dev/null | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6861e7645970832094a44a3904ea5f24