### PR TITLE
Fix charset meta tags and fill spec metadata

### DIFF
--- a/original-htmls/html/adv-forms/css-dynamic-content-change.html
+++ b/original-htmls/html/adv-forms/css-dynamic-content-change.html
@@ -3,9 +3,9 @@
 <html lang="en" data-cat="adv-forms" data-order="0" data-ver="6.3">
 <head>
   <title>Dynamic Content</title>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting, pdf‑forms, javascript, listbox">
-  <meta name="specification" content="Form">
+  <meta name="specification" content="Forms‑JavaScript‑Dynamic‑List"/>
   <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
   <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
   <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/adv-forms/css-form-demo-1.html
+++ b/original-htmls/html/adv-forms/css-form-demo-1.html
@@ -5,7 +5,7 @@
   <title>Form Demo</title>
   <meta charset="UTF-8"/>
   <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting, forms, interactive"/>
-  <meta name="specification" content="CSS-Form-Demo/>
+  <meta name="specification" content="HTML-Forms"/>
   <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
   <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
   <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/barcode/css-barcode-1.html
+++ b/original-htmls/html/barcode/css-barcode-1.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>Barcode – Antenna House, Inc.</title>
   <meta name="title" content="Barcode – Antenna House, Inc.">
   <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/block/css-column-with-container-1.html
+++ b/original-htmls/html/block/css-column-with-container-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Multicol"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-condensed-text-align-last-1.html
+++ b/original-htmls/html/block/css-condensed-text-align-last-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-diagonal-border-1.html
+++ b/original-htmls/html/block/css-diagonal-border-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-display-align-justify-1.html
+++ b/original-htmls/html/block/css-display-align-justify-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-indent-border-padding-1.html
+++ b/original-htmls/html/block/css-indent-border-padding-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-keep-together-1.html
+++ b/original-htmls/html/block/css-keep-together-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-keep-together-within-dimension-1.html
+++ b/original-htmls/html/block/css-keep-together-within-dimension-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-keep-with-next-1.html
+++ b/original-htmls/html/block/css-keep-with-next-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-line-style-1.html
+++ b/original-htmls/html/block/css-line-style-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-line-style-2.html
+++ b/original-htmls/html/block/css-line-style-2.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-list-block-1.html
+++ b/original-htmls/html/block/css-list-block-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-overflow-1.html
+++ b/original-htmls/html/block/css-overflow-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-overflow-2.html
+++ b/original-htmls/html/block/css-overflow-2.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-space-after-1.html
+++ b/original-htmls/html/block/css-space-after-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/block/css-text-overflow-1.html
+++ b/original-htmls/html/block/css-text-overflow-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="block" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>Rendering where inline content overflows – Antenna House, Inc.</title>
   <meta name="author" content="Antenna House, Inc.">
   <meta name="keywords" content="overflow,-ah-text-overflow">

--- a/original-htmls/html/block/css-transform-1.html
+++ b/original-htmls/html/block/css-transform-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-char-attr-1.html
+++ b/original-htmls/html/character/css-char-attr-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-emoji-1.html
+++ b/original-htmls/html/character/css-emoji-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-font-face-1.html
+++ b/original-htmls/html/character/css-font-face-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-font-face-2.html
+++ b/original-htmls/html/character/css-font-face-2.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="character" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <meta name="document-title" content="Specify the Unicode range of the font added by -ah-font-face, and adjust the font size – Antenna House, Inc.">
   <meta name="displaydoctitle" content="true">
   <meta name="keywords" content="font-face">

--- a/original-htmls/html/character/css-font-size-1.html
+++ b/original-htmls/html/character/css-font-size-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-font-stretch-1.html
+++ b/original-htmls/html/character/css-font-stretch-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Fonts"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-font-variant-east-asian-1.html
+++ b/original-htmls/html/character/css-font-variant-east-asian-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-glyph-orientation-1.html
+++ b/original-htmls/html/character/css-glyph-orientation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-initial-letters.html
+++ b/original-htmls/html/character/css-initial-letters.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="character" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Drop Caps – Antenna House, Inc.</title>
     <meta name="keywords" content="-ah-initial-letters">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/character/css-quotetype-1.html
+++ b/original-htmls/html/character/css-quotetype-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-text-replace-1.html
+++ b/original-htmls/html/character/css-text-replace-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-text-shadow-1.html
+++ b/original-htmls/html/character/css-text-shadow-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-text-stroke-1.html
+++ b/original-htmls/html/character/css-text-stroke-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-text-transform-1.html
+++ b/original-htmls/html/character/css-text-transform-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/character/css-white-space-1.html
+++ b/original-htmls/html/character/css-white-space-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/color/css-color-CMYK-1.html
+++ b/original-htmls/html/color/css-color-CMYK-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/color/css-color-Gray-1.html
+++ b/original-htmls/html/color/css-color-Gray-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/color/css-color-Pantone-1.html
+++ b/original-htmls/html/color/css-color-Pantone-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/color/css-color-hsl-1.html
+++ b/original-htmls/html/color/css-color-hsl-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Color"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/color/css-color-named-1.html
+++ b/original-htmls/html/color/css-color-named-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Color"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/color/css-color-transparent-1.html
+++ b/original-htmls/html/color/css-color-transparent-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/float/css-axf-float-page-1.html
+++ b/original-htmls/html/float/css-axf-float-page-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/float/css-float-column-1.html
+++ b/original-htmls/html/float/css-float-column-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/float/css-float-multicol-1.html
+++ b/original-htmls/html/float/css-float-multicol-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/float/css-float-x-alternate-1.html
+++ b/original-htmls/html/float/css-float-x-alternate-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/float/css-sidefloat-1.html
+++ b/original-htmls/html/float/css-sidefloat-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/float/css-table-float-move-1.html
+++ b/original-htmls/html/float/css-table-float-move-1.html
@@ -3,11 +3,11 @@
 <html lang="en" data-cat="float" data-order="0" data-ver="6.3">
 <head>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>Float move examples – Antenna House, Inc.</title>
   <!--
     This HTML/CSS replicates the original FO structure and text,

--- a/original-htmls/html/graphics/css-3d-embedding.html
+++ b/original-htmls/html/graphics/css-3d-embedding.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Sample of 3D</title>
     <meta name="subject" content="">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/graphics/css-allowed-height-width-scale-1.html
+++ b/original-htmls/html/graphics/css-allowed-height-width-scale-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-background-image-gradient-1.html
+++ b/original-htmls/html/graphics/css-background-image-gradient-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-display-alttext-1.html
+++ b/original-htmls/html/graphics/css-display-alttext-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-graphics-1.html
+++ b/original-htmls/html/graphics/css-graphics-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-graphics-cgm-1.html
+++ b/original-htmls/html/graphics/css-graphics-cgm-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-graphics-data-1.html
+++ b/original-htmls/html/graphics/css-graphics-data-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-graphics-eps-1.html
+++ b/original-htmls/html/graphics/css-graphics-eps-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-graphics-svg-1.html
+++ b/original-htmls/html/graphics/css-graphics-svg-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-graphics-svg-2.html
+++ b/original-htmls/html/graphics/css-graphics-svg-2.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/graphics/css-scale-to-fit-1.html
+++ b/original-htmls/html/graphics/css-scale-to-fit-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css--hyphenation-1.html
+++ b/original-htmls/html/line/css--hyphenation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-adjust-last-line-spacing-1.html
+++ b/original-htmls/html/line/css-adjust-last-line-spacing-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-avoid-widow-words-cjk-punctuation-1.html
+++ b/original-htmls/html/line/css-avoid-widow-words-cjk-punctuation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-avoid-widow-words.html
+++ b/original-htmls/html/line/css-avoid-widow-words.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-flush-zone-1.html
+++ b/original-htmls/html/line/css-flush-zone-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="line" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <meta name="document-title" content="Adjusts the space at the end of the last line – Antenna House, Inc.">
   <meta name="displaydoctitle" content="true">
   <meta name="keywords" content="flush-zone">

--- a/original-htmls/html/line/css-hanging-punctuation-1.html
+++ b/original-htmls/html/line/css-hanging-punctuation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Text"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-hyphenate-1.html
+++ b/original-htmls/html/line/css-hyphenate-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Text"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-hyphenate-caps-word-1.html
+++ b/original-htmls/html/line/css-hyphenate-caps-word-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Text"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-hyphenate-hyphenated-word-1.html
+++ b/original-htmls/html/line/css-hyphenate-hyphenated-word-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Text"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-intrude-into-punctuation-1.html
+++ b/original-htmls/html/line/css-intrude-into-punctuation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-kerning-mode-1.html
+++ b/original-htmls/html/line/css-kerning-mode-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-leader-alignment.html
+++ b/original-htmls/html/line/css-leader-alignment.html
@@ -3,7 +3,7 @@
 <html lang="en" data-cat="line" data-order="0" data-ver="6.3">
 <head>
     <meta charset="UTF-8"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-letter-spacing-1.html
+++ b/original-htmls/html/line/css-letter-spacing-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-ligature-mode-1.html
+++ b/original-htmls/html/line/css-ligature-mode-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-break-1.html
+++ b/original-htmls/html/line/css-line-break-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-break-BPIL-1.html
+++ b/original-htmls/html/line/css-line-break-BPIL-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-continued-mark-1.html
+++ b/original-htmls/html/line/css-line-continued-mark-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-height-1.html
+++ b/original-htmls/html/line/css-line-height-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-height-2.html
+++ b/original-htmls/html/line/css-line-height-2.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-height-3.html
+++ b/original-htmls/html/line/css-line-height-3.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-height-shift-adjustment-1.html
+++ b/original-htmls/html/line/css-line-height-shift-adjustment-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-number-2.html
+++ b/original-htmls/html/line/css-line-number-2.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="line" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <meta name="document-title" content="Independent line numbering in table columns – Antenna House, Inc.">
   <meta name="displaydoctitle" content="true">
   <meta name="keywords" content="line-number">

--- a/original-htmls/html/line/css-line-number-except-continued-line-1.html
+++ b/original-htmls/html/line/css-line-number-except-continued-line-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-number-orientation-1.html
+++ b/original-htmls/html/line/css-line-number-orientation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-line-number-show-1.html
+++ b/original-htmls/html/line/css-line-number-show-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="line" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <meta name="document-title" content="Line numbers to always show – Antenna House, Inc.">
   <meta name="displaydoctitle" content="true">
   <meta name="keywords" content="line-number, line-number-show">

--- a/original-htmls/html/line/css-line-stacking-strategy-1.html
+++ b/original-htmls/html/line/css-line-stacking-strategy-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-punctuation-spacing-1.html
+++ b/original-htmls/html/line/css-punctuation-spacing-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-punctuation-trim-1.html
+++ b/original-htmls/html/line/css-punctuation-trim-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-text-align-1.html
+++ b/original-htmls/html/line/css-text-align-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-text-autospace-1.html
+++ b/original-htmls/html/line/css-text-autospace-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-text-indent-if-first-on-page-1.html
+++ b/original-htmls/html/line/css-text-indent-if-first-on-page-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-text-justify-trim-1.html
+++ b/original-htmls/html/line/css-text-justify-trim-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/line/css-unbreakable-words-1.html
+++ b/original-htmls/html/line/css-unbreakable-words-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-border-style.html
+++ b/original-htmls/html/misc/css-border-style.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-cell-repeat-marker.html
+++ b/original-htmls/html/misc/css-cell-repeat-marker.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-display-align.html
+++ b/original-htmls/html/misc/css-display-align.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-document-info.html
+++ b/original-htmls/html/misc/css-document-info.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="misc" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>document-info extension demonstration</title>
     <meta name="author" content="Alex Critchfield, Antenna House">
     <meta name="keywords" content="extensions, document-info">

--- a/original-htmls/html/misc/css-float-in-change-bar.html
+++ b/original-htmls/html/misc/css-float-in-change-bar.html
@@ -3,7 +3,7 @@
 <html data-cat="misc" data-order="0" data-ver="6.3">
 <head>
     <meta charset="UTF-8"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-font-from-external-link.html
+++ b/original-htmls/html/misc/css-font-from-external-link.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html data-cat="misc" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-<meta charset="UTF-8">
+<meta charset="UTF-8"/>
 <title>font-face extension demonstration</title>
 <meta name="author" content="Alex Critchfield, Antenna House">
 <meta name="keywords" content="extensions, font-face">

--- a/original-htmls/html/misc/css-font-size-adjust-extension.html
+++ b/original-htmls/html/misc/css-font-size-adjust-extension.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-font-stretch-extension.html
+++ b/original-htmls/html/misc/css-font-stretch-extension.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-font-variant.html
+++ b/original-htmls/html/misc/css-font-variant.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-force-page-count.html
+++ b/original-htmls/html/misc/css-force-page-count.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-format.html
+++ b/original-htmls/html/misc/css-format.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-internal-destination.html
+++ b/original-htmls/html/misc/css-internal-destination.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-overflow.html
+++ b/original-htmls/html/misc/css-overflow.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/misc/css-punctuation-spacing (1).html
+++ b/original-htmls/html/misc/css-punctuation-spacing (1).html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html data-cat="misc" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <meta name="author" content="Alex Critchfield, Antenna House">
     <meta name="keywords" content="extensions, punctuation, spacing, sample, example">
     <meta name="subject" content="punctuation spacing extensions">

--- a/original-htmls/html/misc/css-table-omit.html
+++ b/original-htmls/html/misc/css-table-omit.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="misc" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <meta name="author" content="Alex Critchfield, Antenna House">
     <meta name="keywords" content="extensions, value, table-omit-header-at-break, table-omit-footer-at-break">
     <meta name="subject" content="table-omit-header-at-break table-omit-footer-at-break extended values">

--- a/original-htmls/html/misc/css-text-transform.html
+++ b/original-htmls/html/misc/css-text-transform.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="misc" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>text-transform extended values example</title>
     <meta name="author" content="Alex Critchfield, Antenna House">

--- a/original-htmls/html/misc/css-zoom.html
+++ b/original-htmls/html/misc/css-zoom.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html data-cat="misc" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>Zoom Document</title>
   <meta name="displaydoctitle" content="true">
 	<meta name="keywords" content="zoom, openaction">

--- a/original-htmls/html/page-set/css-index-page-citation-1.html
+++ b/original-htmls/html/page-set/css-index-page-citation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/page-set/css-marker-1.html
+++ b/original-htmls/html/page-set/css-marker-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="page-set" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>Thumb index – Antenna House, Inc.</title>
   <meta name="title" content="Thumb Index">
   <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/page-set/css-page-number-1.html
+++ b/original-htmls/html/page-set/css-page-number-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/page-set/css-page-number-citation-1.html
+++ b/original-htmls/html/page-set/css-page-number-citation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/page-set/css-page-number-format-1.html
+++ b/original-htmls/html/page-set/css-page-number-format-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/page-set/css-reverse-page-number-1.html
+++ b/original-htmls/html/page-set/css-reverse-page-number-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-Bookmark-1.html
+++ b/original-htmls/html/pdf-features/css-Bookmark-1.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-annotation-1.html
+++ b/original-htmls/html/pdf-features/css-annotation-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-annotation-create-modifydate-1.html
+++ b/original-htmls/html/pdf-features/css-annotation-create-modifydate-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-basic-link-1.html
+++ b/original-htmls/html/pdf-features/css-basic-link-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-destination-type-1.html
+++ b/original-htmls/html/pdf-features/css-destination-type-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-document-info-1.html
+++ b/original-htmls/html/pdf-features/css-document-info-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-document-info-2.html
+++ b/original-htmls/html/pdf-features/css-document-info-2.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-expansion-text-1.html
+++ b/original-htmls/html/pdf-features/css-expansion-text-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-form-field-1.html
+++ b/original-htmls/html/pdf-features/css-form-field-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-form-field-2.html
+++ b/original-htmls/html/pdf-features/css-form-field-2.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-form-field-event-1.html
+++ b/original-htmls/html/pdf-features/css-form-field-event-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="pdf-features" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Form Event – Antenna House, Inc.</title>
     <meta name="keywords" content="form,form-field,AcroForms,JavaScript,setAction,openaction">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/pdf-features/css-import-annotation-types-1.html
+++ b/original-htmls/html/pdf-features/css-import-annotation-types-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="pdf-features" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Keeping the annotation in the embedded PDF – Antenna House, Inc.</title>
     <meta name="keywords" content="import-annotation-types">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/pdf-features/css-multimedia-1.html
+++ b/original-htmls/html/pdf-features/css-multimedia-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="pdf-features" data-order="0" data-ver="6.3">
 	<head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-		<meta charset="UTF-8">
+		<meta charset="UTF-8"/>
 				<meta name="displaydoctitle"
 				      content="true">
 					<meta name="keywords"

--- a/original-htmls/html/pdf-features/css-multimedia-treatment-1.html
+++ b/original-htmls/html/pdf-features/css-multimedia-treatment-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="pdf-features" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Embedded and External Multimedia Data – Antenna House, Inc.</title>
     <meta name="subject" content="The document subject">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/pdf-features/css-overprint-1.html
+++ b/original-htmls/html/pdf-features/css-overprint-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-pdf-embedding-1.html
+++ b/original-htmls/html/pdf-features/css-pdf-embedding-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="pdf-features" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>PDF Embedding – Antenna House, Inc.</title>
     <meta name="author" content="Antenna House, Inc.">
     <meta name="keywords" content="img,background-image,PDF">

--- a/original-htmls/html/pdf-features/css-pdf-embedding-2.html
+++ b/original-htmls/html/pdf-features/css-pdf-embedding-2.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="pdf-features" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>PDF embedding by specifying pages</title>
   <meta name="author" content="Antenna House, Inc.">
   <meta name="keywords" content="external-graphic, img, PDF">

--- a/original-htmls/html/pdf-features/css-pdf-embedding-3.html
+++ b/original-htmls/html/pdf-features/css-pdf-embedding-3.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="pdf-features" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Printing by merging embedded PDF – Antenna House, Inc.</title>
     <meta name="keywords" content="background-image, container element, position: absolute, PDF">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/pdf-features/css-printer-marks-1.html
+++ b/original-htmls/html/pdf-features/css-printer-marks-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/pdf-features/css-richmedia-1.html
+++ b/original-htmls/html/pdf-features/css-richmedia-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="pdf-features" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-<meta charset="UTF-8">
+<meta charset="UTF-8"/>
 <meta name="keywords" content="object,video,-ah-multimedia-treatment,content-type">
 <meta name="author" content="Antenna House, Inc.">
 <title>Rich Media Annotations – Antenna House, Inc.</title>

--- a/original-htmls/html/ruby/css-axf-ruby-1.html
+++ b/original-htmls/html/ruby/css-axf-ruby-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/ruby/css-axf-ruby-2.html
+++ b/original-htmls/html/ruby/css-axf-ruby-2.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/ruby/css-axf-ruby-3.html
+++ b/original-htmls/html/ruby/css-axf-ruby-3.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/ruby/css-axf-ruby-4.html
+++ b/original-htmls/html/ruby/css-axf-ruby-4.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/ruby/css-text-emphasis-style-1.html
+++ b/original-htmls/html/ruby/css-text-emphasis-style-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-axf-odd-or-even-1.html
+++ b/original-htmls/html/structure/css-axf-odd-or-even-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-axf-page-position-1.html
+++ b/original-htmls/html/structure/css-axf-page-position-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-axf-region-1.html
+++ b/original-htmls/html/structure/css-axf-region-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-clip-1.html
+++ b/original-htmls/html/structure/css-background-clip-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-color-1.html
+++ b/original-htmls/html/structure/css-background-color-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-content-height-1.html
+++ b/original-htmls/html/structure/css-background-content-height-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-image-1.html
+++ b/original-htmls/html/structure/css-background-image-1.html
@@ -3,7 +3,7 @@
 <html lang="en" data-cat="structure" data-order="0" data-ver="6.3">	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Backgrounds"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-image-2.html
+++ b/original-htmls/html/structure/css-background-image-2.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-origin-1.html
+++ b/original-htmls/html/structure/css-background-origin-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-position-1.html
+++ b/original-htmls/html/structure/css-background-position-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Backgrounds"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-repeat-1.html
+++ b/original-htmls/html/structure/css-background-repeat-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Backgrounds"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-background-size-1.html
+++ b/original-htmls/html/structure/css-background-size-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-break-page-1.html
+++ b/original-htmls/html/structure/css-break-page-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-change-bar-1.html
+++ b/original-htmls/html/structure/css-change-bar-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-change-bar-2.html
+++ b/original-htmls/html/structure/css-change-bar-2.html
@@ -3,7 +3,7 @@
 <html data-cat="structure" data-order="0" data-ver="6.3">
 <head>
     <meta charset="UTF-8"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-column-rule-1.html
+++ b/original-htmls/html/structure/css-column-rule-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-footnote-1.html
+++ b/original-htmls/html/structure/css-footnote-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-footnote-column-1.html
+++ b/original-htmls/html/structure/css-footnote-column-1.html
@@ -5,7 +5,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-footnote-max-height-1.html
+++ b/original-htmls/html/structure/css-footnote-max-height-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-footnote-number-1.html
+++ b/original-htmls/html/structure/css-footnote-number-1.html
@@ -3,11 +3,11 @@
 <html lang="en" data-cat="structure" data-order="0" data-ver="6.3">
 <head>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8"/>
   <title>Creating a footnote number and specifying a default value</title>
   <style>
     @page {

--- a/original-htmls/html/structure/css-footnote-suppress-duplicate-1.html
+++ b/original-htmls/html/structure/css-footnote-suppress-duplicate-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-multi-column-1.html
+++ b/original-htmls/html/structure/css-multi-column-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-Multicol"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-page-layout-1.html
+++ b/original-htmls/html/structure/css-page-layout-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-page-seq-master-2.html
+++ b/original-htmls/html/structure/css-page-seq-master-2.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-page-seq-master-3.html
+++ b/original-htmls/html/structure/css-page-seq-master-3.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-region-1.html
+++ b/original-htmls/html/structure/css-region-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-GCPM"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/structure/css-region-2.html
+++ b/original-htmls/html/structure/css-region-2.html
@@ -3,11 +3,11 @@
 <html lang="en" data-cat="structure" data-order="0" data-ver="6.3">
 	<head>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-		<meta charset="UTF-8">
+		<meta charset="UTF-8"/>
 			<title>Creating regions in a body region</title>
 			<style>
 @page {

--- a/original-htmls/html/structure/css-region-start-end-direction-1.html
+++ b/original-htmls/html/structure/css-region-start-end-direction-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS3-WritingModes"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-from-table-column-1.html
+++ b/original-htmls/html/table/css-from-table-column-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-justify-rowspan-height-1.html
+++ b/original-htmls/html/table/css-justify-rowspan-height-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-arrangement-1.html
+++ b/original-htmls/html/table/css-table-arrangement-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-background-1.html
+++ b/original-htmls/html/table/css-table-background-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="CSS2.1"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-border-conflict-resolution-1.html
+++ b/original-htmls/html/table/css-table-border-conflict-resolution-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-border-padding-1.html
+++ b/original-htmls/html/table/css-table-border-padding-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-cell-repeated-marker-1.html
+++ b/original-htmls/html/table/css-table-cell-repeated-marker-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-display-align-1.html
+++ b/original-htmls/html/table/css-table-display-align-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-function-sample.html
+++ b/original-htmls/html/table/css-table-function-sample.html
@@ -3,11 +3,11 @@
 <html lang="en" data-cat="table" data-order="0" data-ver="6.3">
 	<head>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-		<meta charset="UTF-8">
+		<meta charset="UTF-8"/>
 			<title>Combining various table features</title>
 			<style>
         @page {

--- a/original-htmls/html/table/css-table-headers-scope-1.html
+++ b/original-htmls/html/table/css-table-headers-scope-1.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="table" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Associating table body cells and table header cells – Antenna House, Inc.</title>
     <meta name="keywords" content="<table-cell,headers,scope,PDF/UA">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/table/css-table-keep-together-overflow.html
+++ b/original-htmls/html/table/css-table-keep-together-overflow.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="table" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-<meta charset="UTF-8">
+<meta charset="UTF-8"/>
 <title>Avoiding table-row overflow due to keep-together.within-*="always" – Antenna House, Inc.</title>
 <meta name="document-title" content="Avoiding table-row overflow due to keep-together.within-*=&quot;always&quot; – Antenna House, Inc.">
 <meta name="displaydoctitle" content="true">

--- a/original-htmls/html/table/css-table-omit-header-footer-1.html
+++ b/original-htmls/html/table/css-table-omit-header-footer-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-omit-header-footer-column-1.html
+++ b/original-htmls/html/table/css-table-omit-header-footer-column-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-retrieve-table-marker.html
+++ b/original-htmls/html/table/css-table-retrieve-table-marker.html
@@ -2,11 +2,11 @@
 <!-- $Id$ -->
 <html lang="en" data-cat="table" data-order="0" data-ver="6.3">
 <head>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Adding a "continued" indicator when a table is split – Antenna House, Inc.</title>
     <meta name="keywords" content="running-elements, table-split, continued-indicator">
     <meta name="author" content="Antenna House, Inc.">

--- a/original-htmls/html/table/css-table-rotate-1.html
+++ b/original-htmls/html/table/css-table-rotate-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-row-widows-orphans-1.html
+++ b/original-htmls/html/table/css-table-row-widows-orphans-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-spanned-1.html
+++ b/original-htmls/html/table/css-table-spanned-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="HTML-Tables"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-width-1.html
+++ b/original-htmls/html/table/css-table-width-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-table-within-page-1.html
+++ b/original-htmls/html/table/css-table-within-page-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>

--- a/original-htmls/html/table/css-text-align-string-1.html
+++ b/original-htmls/html/table/css-text-align-string-1.html
@@ -4,7 +4,7 @@
 	<head>
     <meta charset="UTF-8"/>
     <meta name="keywords" content="Antenna House Formatter, CSS, Paged Media, formatting"/>
-    <meta name="specification" content=""/>
+    <meta name="specification" content="AH-Formatter-Extensions"/>
 <link rel="stylesheet" href="../../css/booklet-print-4th.css"/>
 <link rel="stylesheet" href="../../css/booklet-page-en.css"/>
 <link rel="stylesheet" href="../../css/css-sample-en.css"/>


### PR DESCRIPTION
## Summary
- convert HTML meta charset tags to self-closing form
- populate empty `specification` meta tags with `AH-Formatter-Extensions`
- assign correct specification names for dynamic form and marker samples
- set precise W3C specification names for several standard CSS samples
- refine spec metadata for common CSS samples

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6865588524488320993f6cd3de401a84